### PR TITLE
Update docs

### DIFF
--- a/packages/docs/docs/user-guide/faq.mdx
+++ b/packages/docs/docs/user-guide/faq.mdx
@@ -6,6 +6,14 @@ hide_table_of_contents: true
 
 # FAQ
 
+## During Setup, the following error occurs: "executing `.ps1` scripts is not allowed due to an ExecutionPolicy"
+
+This can be solved by running the following command in a PowerShell (credits to https://stackoverflow.com/a/49112322/8255842):
+
+```powershell
+Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted
+```
+
 ## Pyra Shows a `filelock._error.Timeout` Exception
 
 In theory, it is possible that Pyra encounters a deadlock when reading state or log files - although we have never encountered it yet. The error message will say something like this:

--- a/packages/docs/docs/user-guide/setup.mdx
+++ b/packages/docs/docs/user-guide/setup.mdx
@@ -14,16 +14,6 @@ The following manual steps are only required at the initial system setup. All fu
 
 :::
 
-:::tip
-
-Sometimes, you might get an error message saying that "executing `.ps1` scripts is not allowed due to an ExecutionPolicy". This can be solved with the following command (credits to https://stackoverflow.com/a/49112322/8255842):
-
-```
-Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted
-```
-
-:::
-
 ### OPUS and CamTracker
 
 Our integration tests use **OPUS 7.8.44** and **CamTracker 3.9.2015.02.03**. Both OPUS and CamTracker are not really available to download, but you will receive them when buying an EM27/SUN system.
@@ -91,6 +81,8 @@ The [**Pyra Setup Tool**](https://github.com/tum-esm/pyra-setup-tool) can be use
         📁 pyra-4.0.6
         📁 ...
 ```
+
+**The setup tool requires you to use a unix-like shell environment (bash/sh/zsh/..., _not_ powershell).**
 
 On the first time, clone the setup tool repo:
 


### PR DESCRIPTION
- Move a note about policy change in PowerShell (not being able to activate a venv )to FAQ 
- Add a bold line that the Pyra Setup Tool needs to run using bash/sh/zsh