### PR TITLE
check_tracker_motor_positions for zero

### DIFF
--- a/packages/core/threads/camtracker_thread.py
+++ b/packages/core/threads/camtracker_thread.py
@@ -291,7 +291,7 @@ class CamTrackerThread(AbstractThread):
                                     continue
                             case "invalid":
                                 logger.error(
-                                    "Restarting CamTracker because tracker offsets are too high."
+                                    "Restarting CamTracker because tracker offsets are zero or too high."
                                 )
                                 CamTrackerProgram.stop(config, logger)
                                 continue
@@ -418,7 +418,8 @@ class CamTrackerThread(AbstractThread):
 
         if (abs(tracker_position.azimuth_offset) <= config.camtracker.motor_offset_threshold) and (
             abs(tracker_position.elevation_offset) <= config.camtracker.motor_offset_threshold
-        ):
+        ) and (
+            (tracker_position.azimuth_offset != 0) and (tracker_position.elevation_offset) != 0):
             return "valid"
         else:
             return "invalid"


### PR DESCRIPTION
if the motor offsets are zero then that indicates an issue with the camera tracking. In reality there is always a non-zero offset when the camera is correctly tracking. in my case there is a zero offset when the ethernet camera is not detected or is disconnected. Currently pyra does not pick up on this and a manual restart of camtracker is required which will often result in successful camera reconnection

@dostuffthatmatters please can you confirm/agree that this is a simple intervention to address this issue.